### PR TITLE
Convert priority string to integer. If not error in foreman/lib/tasks.rb...

### DIFF
--- a/lib/foreman_hooks/orchestration_hook.rb
+++ b/lib/foreman_hooks/orchestration_hook.rb
@@ -33,7 +33,7 @@ module ForemanHooks::OrchestrationHook
       basename = File.basename(filename)
       priority = basename =~ /^(\d+)/ ? $1 : 10000 + (counter += 1)
       logger.debug "Queuing hook #{basename} for #{self.class.to_s}##{event} at priority #{priority}"
-      queue.create(:name   => "Hook: #{basename}", :priority => priority,
+      queue.create(:name   => "Hook: #{basename}", :priority => priority.to_i,
                    :action => [HookRunner.new(filename, self, event.to_s),
                                event.to_s == 'destroy' ? :hook_execute_del : :hook_execute_set])
     end


### PR DESCRIPTION
There is an error in foreman if the priority of the queue job is not integer but string (which should always be the case).
This leads to an error in lib/foreman/task.rb:<=> method.
This patch should fix this problem.

Let me know what you think.
