### PR TITLE
fixes #3624 - raise exception when hook fails

### DIFF
--- a/lib/foreman_hooks.rb
+++ b/lib/foreman_hooks.rb
@@ -4,6 +4,8 @@ module ForemanHooks
   require 'foreman_hooks/callback_hooks'
   require 'foreman_hooks/orchestration_hook'
 
+  class Error < RuntimeError; end
+
   class << self
     def hooks_root
       File.join(Rails.application.root, 'config', 'hooks')

--- a/lib/foreman_hooks/util.rb
+++ b/lib/foreman_hooks/util.rb
@@ -11,9 +11,8 @@ module ForemanHooks::Util
                 exec_hook_int(self.to_json, *args)
               end.success?
 
-    unless success
-      logger.warn "Hook failure running `#{args.join(' ')}`: #{$?}"
-    end
+    # Raising here causes Foreman Orchestration to correctly show error bubble in GUI
+    raise ForemanHooks::Error.new "Hook failure running `#{args.join(' ')}`: #{$?}" unless success
     success
   end
 


### PR DESCRIPTION
Previously, failure of a hook was silent in the GUI: no error bubble.   If foreman_hook raises, the error is correctly generated:

![screen shot 2013-11-15 at 5 56 07 pm](https://f.cloud.github.com/assets/429763/1551654/9e22c30e-4e17-11e3-9b6d-77e4d56d41a2.png)

I'm not sure if this the erhm, "rubonic" way to do this, though.
