### PR TITLE
support for Host::Discovered objects [issue 24]

### DIFF
--- a/lib/foreman_hooks/util.rb
+++ b/lib/foreman_hooks/util.rb
@@ -4,9 +4,11 @@ module ForemanHooks::Util
   extend ActiveSupport::Concern
 
   def render_hook_type
-    case self
-      when Host::Managed
+    case self.class.name
+      when "Host::Managed"
         'host'
+      when "Host::Discovered"
+        'discovered_host'
       else
         self.class.name.downcase
     end


### PR DESCRIPTION
This is needed so that the discovered_hosts/*.rabl files from the foreman_discovery plugin are available fore rendering. Please review this.

Thanks,
-PP