### PR TITLE
render_hook_json: Use absolute path to views

### DIFF
--- a/lib/foreman_hooks/util.rb
+++ b/lib/foreman_hooks/util.rb
@@ -17,7 +17,8 @@ module ForemanHooks::Util
   def render_hook_json
     # APIv2 has some pretty good templates.  We could extend them later in special cases.
     # Wrap them in a root node for pre-1.4 compatibility
-    json = Rabl.render(self, "api/v2/#{render_hook_type.tableize}/show", :view_path => 'app/views', :format => :json)
+    view_path = Rails.root.join('app', 'views')
+    json = Rabl.render(self, "api/v2/#{render_hook_type.tableize}/show", :view_path => view_path, :format => :json)
     %Q|{"#{render_hook_type}":#{json}}|
   rescue => e
     logger.warn "Unable to render #{self} (#{self.class}) using RABL: #{e.message}"


### PR DESCRIPTION
Under Katello, foreman_hooks is loaded under the foreman-tasks process
which is separate from the main foreman process and has a different
working directory.  The result is that when hooks run from jobs executed
by foreman-tasks, they raise an exception when rendering the hook json
due to not being able to find the views.

Fix that by specifying an absolute path to the views, based on the Rails
root.

Fixes #28