### PR TITLE
README update, prevent broken pipe error

### DIFF
--- a/lib/foreman_hooks/util.rb
+++ b/lib/foreman_hooks/util.rb
@@ -44,8 +44,12 @@ module ForemanHooks::Util
       Open3.capture2e(*args.push(:stdin_data => stdin_data))
     else  # 1.8
       Open3.popen3(*args) do |stdin,stdout,stderr|
-        stdin.write(stdin_data)
-        stdin.close
+        begin
+          stdin.write(stdin_data)
+          stdin.close
+        rescue Errno::EPIPE
+          logger.debug "Foreman hook input data skipped, closed pipe"
+        end
         # we could still deadlock here, it'd ideally select() on stdout+err
         output = stderr.read
       end


### PR DESCRIPTION
Review of README because Red Hat doco team had a lot of questions when
processing this and I decided to fix this. Some comments inline.

Also this fixes EPIPE which can occur when script closes STDIN.