### PR TITLE
Fixed RABL view paths

### DIFF
--- a/lib/foreman_hooks/util.rb
+++ b/lib/foreman_hooks/util.rb
@@ -19,7 +19,7 @@ module ForemanHooks::Util
   def render_hook_json
     # APIv2 has some pretty good templates.  We could extend them later in special cases.
     # Wrap them in a root node for pre-1.4 compatibility
-    view_path = Rails.root.join('app', 'views')
+    view_path = ActionController::Base.view_paths.collect(&:to_path)
     json = Rabl.render(self, "api/v2/#{render_hook_type.tableize}/show", :view_path => view_path, :format => :json)
     %Q|{"#{render_hook_type}":#{json}}|
   rescue => e


### PR DESCRIPTION
When hooking host/create or after_create and creating it via UI with Katello
plugin enabled, create RABL does reference facet code references something from
Katello leading to error:

```
Cannot find rabl template 'katello/api/v2/content_facet/base_with_root' within
registered (["app/views", "/usr/share/foreman/app/views"]) view paths!
```

This is because Katello extend the base RABL with some extra things.