### PR TITLE
Task name is now unique and post queue mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,21 @@ automatically trigger a rollback of the action. A rollback is performed as
 an opposite action (e.g. for DHCP record creation a rollback action is
 destroy).
 
-To add hooks to these, use these event names:
+The following hooks are executed during `around_save` Rails callback:
 
 * `create`
 * `update`
+
+The following hooks are executed during `on_destroy` Rails callback:
+
 * `destroy`
+
+The following hooks are executed during `after_commit` Rails callback:
+
+* `postcreate`
+* `postupdate`
+
+The major difference between `create` and `postcreate` (or update respectively) is how late the hook is called during save operation. In the former case when a hook fails it starts rollback and operation can be still cancelled. In the latter case object was already saved and there is no way of cancelling the operation, but all referenced data should be properly loaded. The advice is to use the latter hooks as they will likely contain all the required data (e.g. nested parameters).
 
 Orchestration hooks can be given a priority by prefixing the filename with the
 priority number, therefore it is possible to order them before or after
@@ -133,7 +143,7 @@ may want to ensure stdin is closed to prevent pipe buffer from filling.
 
 Some arguments are available as environment variables:
 
-Variable | Description 
+Variable | Description
 -------- | -----------
 FOREMAN_HOOKS_USER | Username of Foreman user
 

--- a/lib/foreman_hooks.rb
+++ b/lib/foreman_hooks.rb
@@ -68,7 +68,7 @@ module ForemanHooks
     end
 
     def attach_hook(klass, events)
-      if events.keys.detect { |event| ['create', 'update', 'destroy'].include? event }
+      if events.keys.detect { |event| ['create', 'update', 'destroy', 'postcreate', 'postupdate'].include? event }
         unless klass.ancestors.include?(ForemanHooks::OrchestrationHook)
           logger.debug "Extending #{klass} with foreman_hooks orchestration hooking support"
           klass.send(:include, ForemanHooks::OrchestrationHook)

--- a/lib/foreman_hooks/orchestration_hook.rb
+++ b/lib/foreman_hooks/orchestration_hook.rb
@@ -33,8 +33,8 @@ module ForemanHooks::OrchestrationHook
     hooks.each do |filename|
       basename = File.basename(filename)
       priority = basename =~ /^(\d+)/ ? $1 : 10000 + (counter += 1)
-      logger.debug "Queuing hook #{basename} for #{self.class.to_s}##{event} at priority #{priority}"
-      queue.create(:name   => "Hook: #{basename}", :priority => priority.to_i,
+      logger.debug "Queuing hook #{filename} for #{self.class.to_s}##{event} at priority #{priority}"
+      queue.create(:name   => "Hook: #{filename}", :priority => priority.to_i,
                    :action => [HookRunner.new(filename, self, event.to_s),
                                event.to_s == 'destroy' ? :hook_execute_del : :hook_execute_set])
     end

--- a/lib/tasks/hooks.rake
+++ b/lib/tasks/hooks.rake
@@ -24,7 +24,7 @@ namespace :hooks do
     events = ActiveRecord::Callbacks::CALLBACKS.map(&:to_s).reject { |e| e.start_with?('around_') }
 
     # 2. List Foreman orchestration callbacks
-    events.concat(['create', 'destroy', 'update']) if model.included_modules.include?(Orchestration)
+    events.concat(['create', 'destroy', 'update', 'postcreate', 'postupdate']) if model.included_modules.include?(Orchestration)
 
     # 3. List custom define_callbacks/define_model_callbacks
     callbacks = model.methods.map { |m| $1 if m =~ /\A_([a-z]\w+)_callbacks\z/ }.compact


### PR DESCRIPTION
There was a change recently in core so orchestration task names must be unique. This was added to detect multiple tasks added twice. If a hook is named `file.sh` and it is in multiple hook directories, it is always added as "Hook: file.sh" so the hook is only added once and rest are always ignored.

This patch includes full filename path, task name is slightly longer but it prevents from ignoring hooks.

I am also adding another commit into this PR - post queue orchestration mechanism. I hope that README explains that all. This needs more testing but generally it is a good idea to let users to hook via post_queue.