### PR TITLE
fix: remove downcase from hook_type render

### DIFF
--- a/lib/foreman_hooks/util.rb
+++ b/lib/foreman_hooks/util.rb
@@ -12,7 +12,7 @@ module ForemanHooks::Util
       when "Audited::Adapters::ActiveRecord::Audit", "Audited::Audit"
         'audit'
       else
-        self.class.name.downcase
+        self.class.name
     end
   end
 


### PR DESCRIPTION
This fixes #56 by removing the downcase call. Because of this call the tableize function got `configreport` which then got transformed to `configreports`. Instead it should have been `config_reports`.